### PR TITLE
Bump Faraday-related dependencies to address compatibility conflicts with other gems

### DIFF
--- a/message_media_messages.gemspec
+++ b/message_media_messages.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |s|
   s.homepage = 'https://developers.messagemedia.com'
   s.license = 'Apache-2.0'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10')
+  s.add_dependency('faraday', '>= 0.10', '<= 2.0')
   s.add_dependency('test-unit', '~> 3.1.5')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
-  s.add_dependency('faraday-http-cache', '~> 1.2.2')
+  s.add_dependency('faraday-http-cache', '~> 2.4.1')
   s.required_ruby_version = '>= 2.0.0'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']


### PR DESCRIPTION
## Background
JobReady Neptune develop is upgraded to Rails 7 https://github.com/rdytech/neptune/pull/8933
JobReady AI - Eddie project started ~8 weeks ago with Rails 6. There are a few of dependencies introduced to support open ai.
A main one is faraday gem upgrade from 0.17.6 to ~> 1.0. It wasn't an issue when using https://rubygems.org/gems/messagemedia_messages_sdk/versions/2.0.3
[faraday](https://rubygems.org/gems/faraday) >= 0.10
[faraday-http-cache](https://rubygems.org/gems/faraday-http-cache) >= 1.2.2

With Rails 7 upgrade, gem is upgraded to https://rubygems.org/gems/messagemedia_messages_sdk/versions/3.0.0
[faraday](https://rubygems.org/gems/faraday) ~> 0.10
[faraday-http-cache](https://rubygems.org/gems/faraday-http-cache) ~> 1.2.2

With the faraday ~> 0.10 change, it means we cannot use faraday 1.0 or above, which is blocker for using ruby-openai Gem https://github.com/alexrudall/ruby-openai

Issue was https://github.com/messagemedia/messages-ruby-sdk/issues/28 a while ago, and there is a PR to address this issue https://github.com/messagemedia/messages-ruby-sdk/pull/26/files. However, it hasn't been resolved.
I don't think the repo is being actively maintained anymore.

In order to solve dependency compatibility conflicts, we forked https://github.com/messagemedia/messages-ruby-sdk
same as https://github.com/moxiworks/messages-ruby-sdk did.

This PR bumps faraday related dependencies to required versions. Jesse Duffield from MoxiWorks mentioned it's been working in Production. https://github.com/messagemedia/messages-ruby-sdk/pull/26#issuecomment-1744214093
We will test it out.